### PR TITLE
Django 1.4-compat

### DIFF
--- a/daguerre/models.py
+++ b/daguerre/models.py
@@ -33,7 +33,7 @@ class ImageManager(models.Manager):
 			image = self.get(image=storage_path)
 		except self.model.DoesNotExist:
 			try:
-				im = default_storage.open(storage_path, mixin=ImageFile)
+				im = default_storage.open(storage_path)
 			except IOError:
 				raise self.model.DoesNotExist("Path could not be opened.")
 


### PR DESCRIPTION
Removed a use of the mixin kwarg for default_storage.open. This should be fine in 1.3 as well, since that wasn't actually being used.
