### PR TITLE
Fixed namedcrop option name

### DIFF
--- a/docs/guides/areas.rst
+++ b/docs/guides/areas.rst
@@ -58,7 +58,7 @@ You can also use the built-in "namedcrop" adjustment force a specific crop.
 
 .. code-block:: html+django
 
-	<img src="{% adjust my_model.image "namedcrop" area="face" %}" />
+	<img src="{% adjust my_model.image "namedcrop" name="face" %}" />
 
 .. image:: /_static/cat_named_crop.jpg
 


### PR DESCRIPTION
At least in version of daguerre for django 1.7+ the name of option for namedcrop is not "area" but "name".
Check it. It's true.