### PR TITLE
Django 1.9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ env:
   - DB=sqlite3 DJANGO=1.8
   - DB=mysql DJANGO=1.8
   - DB=postgres DJANGO=1.8
+  - DB=sqlite3 DJANGO=1.9
+  - DB=mysql DJANGO=1.9
+  - DB=postgres DJANGO=1.9
 matrix:
   exclude:
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,12 @@ matrix:
       env: DB=mysql DJANGO=1.7
     - python: "3.5"
       env: DB=postgres DJANGO=1.7
+    - python: "3.3"
+      env: DB=sqlite3 DJANGO=1.9
+    - python: "3.3"
+      env: DB=mysql DJANGO=1.9
+    - python: "3.3"
+      env: DB=postgres DJANGO=1.9
 install:
   - pip install . --no-deps
   - pip install --no-deps -r test_project/requirements-$DJANGO.txt

--- a/daguerre/helpers.py
+++ b/daguerre/helpers.py
@@ -2,13 +2,14 @@ import datetime
 import itertools
 import ssl
 
+from collections import OrderedDict
+
 from django.conf import settings
 from django.core.files.base import File
 from django.core.files.storage import default_storage
 from django.core.urlresolvers import reverse
 from django.http import QueryDict
 from django.template import Variable, VariableDoesNotExist, TemplateSyntaxError
-from django.utils.datastructures import SortedDict
 import six
 from six.moves import http_client
 try:
@@ -202,8 +203,8 @@ class AdjustmentHelper(object):
 
     @classmethod
     def make_security_hash(cls, kwargs):
-        kwargs = SortedDict(kwargs)
-        kwargs.keyOrder.sort()
+        kwargs = OrderedDict(kwargs)
+        kwargs.keys().sort()
         args = list(itertools.chain(kwargs.keys(), kwargs.values()))
         return make_hash(settings.SECRET_KEY, step=2, *args)
 
@@ -227,7 +228,7 @@ class AdjustmentHelper(object):
 
     @classmethod
     def from_querydict(cls, image_or_storage_path, querydict, secure=False, generate=False):
-        kwargs = SortedDict()
+        kwargs = OrderedDict()
         for verbose, short in six.iteritems(cls.query_map):
             if short in querydict:
                 kwargs[verbose] = querydict[short]

--- a/daguerre/helpers.py
+++ b/daguerre/helpers.py
@@ -204,7 +204,6 @@ class AdjustmentHelper(object):
     @classmethod
     def make_security_hash(cls, kwargs):
         kwargs = OrderedDict(kwargs)
-        kwargs.keys().sort()
         args = list(itertools.chain(kwargs.keys(), kwargs.values()))
         return make_hash(settings.SECRET_KEY, step=2, *args)
 

--- a/daguerre/helpers.py
+++ b/daguerre/helpers.py
@@ -203,7 +203,7 @@ class AdjustmentHelper(object):
 
     @classmethod
     def make_security_hash(cls, kwargs):
-        kwargs = OrderedDict(kwargs)
+        kwargs = OrderedDict(sorted(kwargs.items(), key=lambda item: item[0], reverse=False))
         args = list(itertools.chain(kwargs.keys(), kwargs.values()))
         return make_hash(settings.SECRET_KEY, step=2, *args)
 

--- a/daguerre/management/commands/_daguerre_preadjust.py
+++ b/daguerre/management/commands/_daguerre_preadjust.py
@@ -4,10 +4,18 @@ from optparse import make_option
 
 from django.conf import settings
 from django.core.management.base import NoArgsCommand, CommandError
-from django.db.models import Model, get_model
+from django.db.models import Model
 from django.db.models.query import QuerySet
 from django.template.defaultfilters import pluralize
 import six
+
+try:
+    # django > 1.7
+    from django.apps import apps
+    get_model = apps.get_model
+except ImportError:
+    # django <= 1.7
+    from django.db.models import get_model
 
 from daguerre.models import AdjustedImage
 from daguerre.helpers import AdjustmentHelper

--- a/test_project/requirements-1.9.txt
+++ b/test_project/requirements-1.9.txt
@@ -1,0 +1,2 @@
+Django==1.9.5
+-r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,11 @@ envlist =
     py27-django18,
     py33-django18,
     py34-django18,
-    py35-django18
+    py35-django18,
+    py27-django19,
+    py33-django19,
+    py34-django19,
+    py35-django19
 
 [testenv]
 changedir = {toxinidir}/test_project
@@ -54,3 +58,27 @@ basepython=python3.5
 deps =
     --no-deps
     -r{toxinidir}/test_project/requirements-1.8.txt
+
+[testenv:py27-django19]
+basepython=python2.7
+deps =
+    --no-deps
+    -r{toxinidir}/test_project/requirements-1.9.txt
+
+[testenv:py33-django19]
+basepython=python3.3
+deps =
+    --no-deps
+    -r{toxinidir}/test_project/requirements-1.9.txt
+
+[testenv:py34-django19]
+basepython=python3.4
+deps =
+    --no-deps
+    -r{toxinidir}/test_project/requirements-1.9.txt
+
+[testenv:py35-django19]
+basepython=python3.5
+deps =
+    --no-deps
+    -r{toxinidir}/test_project/requirements-1.9.txt

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist =
     py34-django18,
     py35-django18,
     py27-django19,
-    py33-django19,
     py34-django19,
     py35-django19
 
@@ -61,12 +60,6 @@ deps =
 
 [testenv:py27-django19]
 basepython=python2.7
-deps =
-    --no-deps
-    -r{toxinidir}/test_project/requirements-1.9.txt
-
-[testenv:py33-django19]
-basepython=python3.3
 deps =
     --no-deps
     -r{toxinidir}/test_project/requirements-1.9.txt

--- a/tox.ini
+++ b/tox.ini
@@ -82,3 +82,4 @@ basepython=python3.5
 deps =
     --no-deps
     -r{toxinidir}/test_project/requirements-1.9.txt
+

--- a/tox.ini
+++ b/tox.ini
@@ -82,4 +82,3 @@ basepython=python3.5
 deps =
     --no-deps
     -r{toxinidir}/test_project/requirements-1.9.txt
-


### PR DESCRIPTION
I've made several changes to make django-daguerre compatibile with Django 1.9.

First I've added testing Django 1.9 against Python 2.7, 3.4 and 3.5. Since official Django support for Python 3.3 has ended with Django 1.8 I have taken out of travis and tox configs testing Django 1.9 against Python 3.3.

[Django 1.9 release notes - Python compatibility](https://docs.djangoproject.com/en/1.9/releases/1.9/#python-compatibility)
> Django 1.9 requires Python 2.7, 3.4, or 3.5. We highly recommend and only officially support the latest release of each series.
> 
> The Django 1.8 series is the last to support Python 3.2 and 3.3.


Second, Django 1.9 dropped it's custom `SortedDict` data type. I've replaced `SortedDict` with Python's `OrderedDict`. Since original author was sorting the `SortedDict` I've sorted the `OrderedDict` accordingly.
Below is the example comparing results of current sorting of `SortedDict` and new sorting of `OrderedDict`.

``` python
# py27 dj18
import itertools
from django.utils.datastructures import SortedDict

kwargs = {'z-word': 1, 'm-word': 4, 'b-word': 2, 'e-word': 22}
kwargs = SortedDict(kwargs)
kwargs.keyOrder.sort()
print(list(itertools.chain(kwargs.keys(), kwargs.values())))
>>> ['b-word', 'e-word', 'm-word', 'z-word', 2, 22, 4, 1]


# py35 dj18
import itertools
from collections import OrderedDict

kwargs = {'z-word': 1, 'm-word': 4, 'b-word': 2, 'e-word': 22}
kwargs = OrderedDict(sorted(kwargs.items(), key=lambda item: item[0], reverse=False))
print(list(itertools.chain(kwargs.keys(), kwargs.values())))
>>> ['b-word', 'e-word', 'm-word', 'z-word', 2, 22, 4, 1]
```

And last `get_model` method is imported from a different path depending on the Django version.