### PR TITLE
Tests for ways that `Image.verify` can fail across different versions of PIL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Requirements
 ------------
 
 * Python 2.7+, 3.3+
-* Pillow 2.7.0
+* Pillow
 * Django 1.7, 1.8 & 1.9
 * Six 1.10.0+
 

--- a/daguerre/helpers.py
+++ b/daguerre/helpers.py
@@ -1,6 +1,7 @@
 import datetime
 import itertools
 import ssl
+import struct
 
 from django.conf import settings
 from django.core.files.base import File
@@ -351,7 +352,7 @@ class AdjustmentHelper(object):
             im = Image.open(im_file)
             try:
                 im.verify()
-            except Exception:
+            except (IndexError, struct.error, SyntaxError):
                 # Raise an IOError if the image isn't valid.
                 raise IOError
             im_file.seek(0)

--- a/docs/guides/installation-and-setup.rst
+++ b/docs/guides/installation-and-setup.rst
@@ -40,7 +40,7 @@ Versions and Requirements
 -------------------------
 
 * Python 2.7+, 3.3+
-* Pillow 2.7.0
+* Pillow
 * Django 1.7, 1.8 & 1.9
 * Six 1.10.0+
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'Pillow<=2.7.0',
+        'Pillow',
         'django>=1.7,<1.10',
         'six>=1.10.0',
     ],

--- a/test_project/requirements.txt
+++ b/test_project/requirements.txt
@@ -1,4 +1,4 @@
-Pillow==2.7.0
+Pillow==3.2.0
 funcsigs==0.4
 mock==1.3.0
 pbr==1.8.1


### PR DESCRIPTION
This pull request:

1. Added mock objects to simulate the different errors PIL raises when it has problems verifying an image.
2. Retains one test that does the verification without mocking. This is sort of future-proofing in case they change the errors again.
3. Removed the assertion on Image.verify -- this is not really our code to test.
4. Removed `except Exception` which I think casts too broad a net. If we think it is necessary I can put it back.

Fixed #78