### PR TITLE
Added missing migration step to the installation/setup docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,10 @@ Add the following or similar anywhere in your URLconf::
        ...
    )
 
+Run the migration command to create the database models::
+
+    python manage.py migrate daguerre
+
 Testing
 -------
 

--- a/docs/guides/installation-and-setup.rst
+++ b/docs/guides/installation-and-setup.rst
@@ -32,6 +32,10 @@ Add Daguerre's URL patterns to your URLconf::
        ...
    )
 
+Run the migration command to create the database models::
+
+    python manage.py migrate daguerre
+
 Now you're ready to :doc:`use Daguerre's template tags </guides/template-tags>`!
 
 .. _versions-and-requirements:


### PR DESCRIPTION
The migration part was missing from the documentation. Admin interface fails silently if migrations are not applied.