### PR TITLE
Hotfix/round dimension

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,6 +9,8 @@ This file lists the people whose contributions have made Daguerre possible.
 * Harris Lapiroff
 * Tomislav Pavlović
 * Violet Peña
+* Filip Todić
+* Stjepan Zlodi
 * Artem Zyryanov
 
 We have tried to include everyone, but if you've made a contribution and are not listed, please open an issue or a pull request with your name.

--- a/daguerre/adjustments.py
+++ b/daguerre/adjustments.py
@@ -101,7 +101,6 @@ class Fit(Adjustment):
     def calculate(self, dims, areas=None):
         image_width, image_height = dims
         width, height = self.kwargs.get('width'), self.kwargs.get('height')
-
         if width is None and height is None:
             return image_width, image_height
 
@@ -118,8 +117,8 @@ class Fit(Adjustment):
         else:
             # Constrain strictly by both dimensions.
             width, height = int(width), int(height)
-            new_width = int(min(width, height * image_ratio))
-            new_height = int(min(height, width / image_ratio))
+            new_width = int(min(width, round(height * image_ratio)))
+            new_height = int(min(height, round(width / image_ratio)))
 
         return new_width, new_height
     calculate.uses_areas = False

--- a/daguerre/adjustments.py
+++ b/daguerre/adjustments.py
@@ -109,11 +109,11 @@ class Fit(Adjustment):
         if height is None:
             # Constrain first by width, then by max_height.
             new_width = int(width)
-            new_height = int(new_width / image_ratio)
+            new_height = int(round(new_width / image_ratio))
         elif width is None:
             # Constrain first by height, then by max_width.
             new_height = int(height)
-            new_width = int(new_height * image_ratio)
+            new_width = int(round(new_height * image_ratio))
         else:
             # Constrain strictly by both dimensions.
             width, height = int(width), int(height)

--- a/daguerre/adjustments.py
+++ b/daguerre/adjustments.py
@@ -101,6 +101,7 @@ class Fit(Adjustment):
     def calculate(self, dims, areas=None):
         image_width, image_height = dims
         width, height = self.kwargs.get('width'), self.kwargs.get('height')
+
         if width is None and height is None:
             return image_width, image_height
 

--- a/daguerre/tests/unit/test_adjustments.py
+++ b/daguerre/tests/unit/test_adjustments.py
@@ -22,9 +22,25 @@ class FitTestCase(BaseTestCase):
         fit = Fit(width=50)
         self.assertEqual(fit.calculate((100, 100)), (50, 50))
 
+    def test_calculate__width_portrait_to_landscape_rounding(self):
+        fit = Fit(width=300)
+        self.assertEqual(fit.calculate((666, 399)), (300, 180))
+
+    def test_calculate__width_landscape_to_portrait_rounding(self):
+        fit = Fit(width=180)
+        self.assertEqual(fit.calculate((399, 666)), (180, 300))
+
     def test_calculate__height(self):
         fit = Fit(height=50)
         self.assertEqual(fit.calculate((100, 100)), (50, 50))
+
+    def test_calculate__height_portrait_to_landscape_rounding(self):
+        fit = Fit(height=180)
+        self.assertEqual(fit.calculate((666, 399)), (300, 180))
+
+    def test_calculate__height_landscape_to_portrait_rounding(self):
+        fit = Fit(height=300)
+        self.assertEqual(fit.calculate((399, 666)), (180, 300))
 
     def test_calculate__smallest(self):
         fit = Fit(width=60, height=50)

--- a/daguerre/tests/unit/test_adjustments.py
+++ b/daguerre/tests/unit/test_adjustments.py
@@ -30,6 +30,14 @@ class FitTestCase(BaseTestCase):
         fit = Fit(width=60, height=50)
         self.assertEqual(fit.calculate((100, 100)), (50, 50))
 
+    def test_calculate__portrait_to_landscape_rounding(self):
+        fit = Fit(width=300, height=180)
+        self.assertEqual(fit.calculate((666, 399)), (300, 180))
+
+    def test_calculate__landscape_to_portrait_rounding(self):
+        fit = Fit(width=180, height=300)
+        self.assertEqual(fit.calculate((399, 666)), (180, 300))
+
     def test_adjust__both(self):
         im = Image.open(self._data_path('100x100.png'))
         fit = Fit(width=50, height=50)


### PR DESCRIPTION
If the newly calculated dimension of an image is a floating point
number and by a fraction smaller than the specified/requested dimension,
it will be taken into consideration and converted into an integer, i.e.
rounded down.

For instance, if the original image is a portrait image of 666x1000px,
and the desired variation is a landscape image of 300x180px, the
original image will be scaled to 666x399px before calculating the
variation. The newly calculated height of the variation is roughly
179.73, making it smaller than the specified height and therefore the
new height. Since the minimum dimension is converted into an integer,
it is rounded down, which results in a loss of one row/column of pixels.

Since the difference between the calculated and the specified height
is infinitesimal, the proposed solution is to round the calculated value. 
This solution is already implemented and I would be happy to contribute.

[Stjepan Zlodi](https://github.com/Ylodi) was added as a co-contributor 
because he was the one who initially found the bug and made a [quick fix](https://github.com/Styria-Digital/django-daguerre/commit/3de0836ad0d352a402db502238e391f345fc9e50). 
Given the circumstances in which this bug arouse, it was a fix with an 
intention of researching it more thoroughly in the future.

We have finally found the time to reproduce this bug, analyze it and 
implement a more acceptable solution.