### PR TITLE
Customize daguerre's directory path

### DIFF
--- a/daguerre/management/commands/_daguerre_clean.py
+++ b/daguerre/management/commands/_daguerre_clean.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import os
 
+from django.conf import settings
 from django.core.files.storage import default_storage
 from django.core.management.base import BaseCommand
 from django.db import models
@@ -8,7 +9,7 @@ from django.template.defaultfilters import pluralize
 import six
 
 from daguerre.helpers import IOERRORS
-from daguerre.models import AdjustedImage, Area
+from daguerre.models import AdjustedImage, Area, DEFAULT_ADJUSTED_IMAGE_PATH
 
 
 class Command(BaseCommand):
@@ -127,12 +128,16 @@ class Command(BaseCommand):
         in the database.
 
         """
+        base_dir = getattr(
+            settings, 'DAGUERRE_ADJUSTED_IMAGE_PATH',
+            DEFAULT_ADJUSTED_IMAGE_PATH)
+
         known_paths = set(
             AdjustedImage.objects.values_list('adjusted', flat=True).distinct()
         )
         orphans = []
         for dirpath, dirnames, filenames in self._walk(
-                'daguerre', topdown=False):
+                base_dir, topdown=False):
             for filename in filenames:
                 filepath = os.path.join(dirpath, filename)
                 if filepath not in known_paths:

--- a/daguerre/migrations/0004_hash_upload_to_dir.py
+++ b/daguerre/migrations/0004_hash_upload_to_dir.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import daguerre.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('daguerre', '0003_auto_20160301_2342'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='adjustedimage',
+            name='adjusted',
+            field=models.ImageField(max_length=45, upload_to=daguerre.models.upload_to),
+        ),
+    ]

--- a/daguerre/models.py
+++ b/daguerre/models.py
@@ -147,6 +147,7 @@ def upload_to(instance, filename):
     # https://docs.djangoproject.com/en/dev/_modules/django/contrib/auth/hashers/
     # https://github.com/django/django/blob/master/django/contrib/auth/hashers.py#L524
     str_for_hash = force_bytes('{} {}'.format(filename, datetime.utcnow()))
+    # Replace all occurrences of 'ad' with 'ag' to avoid ad blockers
     hash_for_dir = hashlib.md5(str_for_hash).hexdigest().replace('ad', 'ag')
     return '{0}/{1}/{2}/{3}'.format(
         image_path, hash_for_dir[0:2], hash_for_dir[2:4], filename)

--- a/daguerre/models.py
+++ b/daguerre/models.py
@@ -138,8 +138,8 @@ def upload_to(instance, filename):
 
     if len(image_path) > 13:
         msg = ('The DAGUERRE_PATH value is more than 13 characters long! '
-               'Falling back to the default value: "{}".'.format(
-                    DAGUERRE_DEFAULT_IMAGE_PATH))
+               'Falling back to the default '
+               'value: "{}".'.format(DAGUERRE_DEFAULT_IMAGE_PATH))
         warnings.warn(msg)
         image_path = DAGUERRE_DEFAULT_IMAGE_PATH
 

--- a/daguerre/models.py
+++ b/daguerre/models.py
@@ -18,6 +18,11 @@ from six.moves import reduce
 
 from daguerre.adjustments import registry
 
+# The default image path where the images will be saved to. Can be overriden by
+# defining the DAGUERRE_ADJUSTED_IMAGE_PATH setting in the project's settings.
+# Example: DAGUERRE_ADJUSTED_IMAGE_PATH = 'img'
+DAGUERRE_DEFAULT_IMAGE_PATH = 'dg'
+
 
 @python_2_unicode_compatible
 class Area(models.Model):
@@ -128,15 +133,15 @@ def upload_to(instance, filename):
       produces letters from 'a' to 'f'.
     """
 
-    first_dir = None
-    if hasattr(settings, 'DAGUERRE_PATH'):
-        first_dir = settings.DAGUERRE_PATH
+    image_path = getattr(
+        settings, 'DAGUERRE_ADJUSTED_IMAGE_PATH', DAGUERRE_DEFAULT_IMAGE_PATH)
 
-    if not first_dir or len(first_dir) > 13:
+    if len(image_path) > 13:
         msg = ('The DAGUERRE_PATH value is more than 13 characters long! '
-               'Falling back to the default value: "dg".')
+               'Falling back to the default value: "{}".'.format(
+                    DAGUERRE_DEFAULT_IMAGE_PATH))
         warnings.warn(msg)
-        first_dir = 'dg'
+        image_path = DAGUERRE_DEFAULT_IMAGE_PATH
 
     # Avoid TypeError on Py3 by forcing the string to bytestring
     # https://docs.djangoproject.com/en/dev/_modules/django/contrib/auth/hashers/
@@ -144,7 +149,7 @@ def upload_to(instance, filename):
     str_for_hash = force_bytes('{} {}'.format(filename, datetime.utcnow()))
     hash_for_dir = hashlib.md5(str_for_hash).hexdigest().replace('ad', 'ag')
     return '{0}/{1}/{2}/{3}'.format(
-        first_dir, hash_for_dir[0:2], hash_for_dir[2:4], filename)
+        image_path, hash_for_dir[0:2], hash_for_dir[2:4], filename)
 
 
 @python_2_unicode_compatible

--- a/daguerre/models.py
+++ b/daguerre/models.py
@@ -158,8 +158,8 @@ class AdjustedImage(models.Model):
     """Represents a managed image adjustment."""
     storage_path = models.CharField(max_length=200)
     # The image name is a 20-character hash, so the max length with a 4-char
-    # extension (jpeg) is 45. The maximum length of the DAGUERRE_PATH string
-    # is 13.
+    # extension (jpeg) is 45. The maximum length of the
+    # DAGUERRE_ADJUSTED_IMAGE_PATH string is 13.
     adjusted = models.ImageField(upload_to=upload_to,
                                  max_length=45)
     requested = models.CharField(max_length=100)

--- a/daguerre/models.py
+++ b/daguerre/models.py
@@ -21,7 +21,7 @@ from daguerre.adjustments import registry
 # The default image path where the images will be saved to. Can be overriden by
 # defining the DAGUERRE_ADJUSTED_IMAGE_PATH setting in the project's settings.
 # Example: DAGUERRE_ADJUSTED_IMAGE_PATH = 'img'
-DAGUERRE_DEFAULT_IMAGE_PATH = 'dg'
+DEFAULT_ADJUSTED_IMAGE_PATH = 'dg'
 
 
 @python_2_unicode_compatible
@@ -134,14 +134,14 @@ def upload_to(instance, filename):
     """
 
     image_path = getattr(
-        settings, 'DAGUERRE_ADJUSTED_IMAGE_PATH', DAGUERRE_DEFAULT_IMAGE_PATH)
+        settings, 'DAGUERRE_ADJUSTED_IMAGE_PATH', DEFAULT_ADJUSTED_IMAGE_PATH)
 
     if len(image_path) > 13:
         msg = ('The DAGUERRE_PATH value is more than 13 characters long! '
                'Falling back to the default '
-               'value: "{}".'.format(DAGUERRE_DEFAULT_IMAGE_PATH))
+               'value: "{}".'.format(DEFAULT_ADJUSTED_IMAGE_PATH))
         warnings.warn(msg)
-        image_path = DAGUERRE_DEFAULT_IMAGE_PATH
+        image_path = DEFAULT_ADJUSTED_IMAGE_PATH
 
     # Avoid TypeError on Py3 by forcing the string to bytestring
     # https://docs.djangoproject.com/en/dev/_modules/django/contrib/auth/hashers/

--- a/daguerre/tests/unit/test_management.py
+++ b/daguerre/tests/unit/test_management.py
@@ -101,20 +101,36 @@ class CleanTestCase(BaseTestCase):
         self.assertTrue(list(duplicates) == [adjusted1] or
                         list(duplicates) == [adjusted2])
 
-    def test_orphaned_files(self):
+    def test_orphaned_files__default_path(self):
         clean = Clean()
         walk_ret = (
-            ('daguerre', ['test'], []),
-            ('daguerre/test', [], ['fake1.png', 'fake2.png', 'fake3.png'])
+            ('dg', ['test'], []),
+            ('dg/test', [], ['fake1.png', 'fake2.png', 'fake3.png'])
         )
         AdjustedImage.objects.create(requested='fit|50|50',
                                      storage_path='whatever.png',
-                                     adjusted='daguerre/test/fake2.png')
+                                     adjusted='dg/test/fake2.png')
         with mock.patch.object(clean, '_walk', return_value=walk_ret) as walk:
             self.assertEqual(clean._orphaned_files(),
-                             ['daguerre/test/fake1.png',
-                              'daguerre/test/fake3.png'])
-            walk.assert_called_once_with('daguerre', topdown=False)
+                             ['dg/test/fake1.png',
+                              'dg/test/fake3.png'])
+            walk.assert_called_once_with('dg', topdown=False)
+
+    @override_settings(DAGUERRE_ADJUSTED_IMAGE_PATH='img')
+    def test_orphaned_files__modified_path(self):
+        clean = Clean()
+        walk_ret = (
+            ('img', ['test'], []),
+            ('img/test', [], ['fake1.png', 'fake2.png', 'fake3.png'])
+        )
+        AdjustedImage.objects.create(requested='fit|50|50',
+                                     storage_path='whatever.png',
+                                     adjusted='img/test/fake2.png')
+        with mock.patch.object(clean, '_walk', return_value=walk_ret) as walk:
+            self.assertEqual(clean._orphaned_files(),
+                             ['img/test/fake1.png',
+                              'img/test/fake3.png'])
+            walk.assert_called_once_with('img', topdown=False)
 
 
 class PreadjustTestCase(BaseTestCase):

--- a/daguerre/tests/unit/test_models.py
+++ b/daguerre/tests/unit/test_models.py
@@ -56,7 +56,7 @@ class AreaTestCase(BaseTestCase):
         AdjustedImage.objects.get(pk=adjusted1.pk)
 
 
-class AdjustesImageUploadToTestCase(BaseTestCase):
+class AdjustedImageUploadToTestCase(BaseTestCase):
 
     def setUp(self):
         self.instance = None

--- a/daguerre/tests/unit/test_models.py
+++ b/daguerre/tests/unit/test_models.py
@@ -1,3 +1,5 @@
+import warnings
+
 from daguerre.models import AdjustedImage, upload_to
 from daguerre.tests.base import BaseTestCase
 
@@ -61,32 +63,54 @@ class AdjustesImageUploadToTestCase(BaseTestCase):
         self.filename = '7014c0bdbedea0e4f4bf.jpeg'
 
     def test_upload_to__default_upload_dir(self):
-        hash_path = upload_to(instance=self.instance, filename=self.filename)
-        self.assertTrue(hash_path.startswith('dg/'))
-        self.assertTrue(hash_path.endswith('/{}'.format(self.filename)))
-        self.assertEqual(len(hash_path.split('/')), 4)
-        self.assertTrue(len(hash_path) < 45)
+        with warnings.catch_warnings(record=True) as w:
+            hash_path = upload_to(
+                instance=self.instance, filename=self.filename)
+            self.assertTrue(hash_path.startswith('dg/'))
+            self.assertTrue(hash_path.endswith('/{}'.format(self.filename)))
+            self.assertEqual(len(hash_path.split('/')), 4)
+            self.assertTrue(len(hash_path) < 45)
+            self.assertEqual(w, [])
 
     @override_settings(DAGUERRE_ADJUSTED_IMAGE_PATH='img')
     def test_upload_to__custom_upload_dir(self):
-        hash_path = upload_to(instance=self.instance, filename=self.filename)
-        self.assertTrue(hash_path.startswith('img/'))
-        self.assertTrue(hash_path.endswith('/{}'.format(self.filename)))
-        self.assertEqual(len(hash_path.split('/')), 4)
-        self.assertTrue(len(hash_path) < 45)
+        with warnings.catch_warnings(record=True) as w:
+            hash_path = upload_to(
+                instance=self.instance, filename=self.filename)
+            self.assertTrue(hash_path.startswith('img/'))
+            self.assertTrue(hash_path.endswith('/{}'.format(self.filename)))
+            self.assertEqual(len(hash_path.split('/')), 4)
+            self.assertTrue(len(hash_path) < 45)
+            self.assertEqual(w, [])
 
     @override_settings(DAGUERRE_ADJUSTED_IMAGE_PATH='0123456789123')
     def test_upload_to__custom_upload_dir_small(self):
-        hash_path = upload_to(instance=self.instance, filename=self.filename)
-        self.assertTrue(hash_path.startswith('0123456789123/'))
-        self.assertTrue(hash_path.endswith('/{}'.format(self.filename)))
-        self.assertEqual(len(hash_path.split('/')), 4)
-        self.assertTrue(len(hash_path) == 45)
+        with warnings.catch_warnings(record=True) as w:
+            hash_path = upload_to(
+                instance=self.instance, filename=self.filename)
+            self.assertTrue(hash_path.startswith('0123456789123/'))
+            self.assertTrue(hash_path.endswith('/{}'.format(self.filename)))
+            self.assertEqual(len(hash_path.split('/')), 4)
+            self.assertTrue(len(hash_path) == 45)
+            self.assertEqual(w, [])
 
     @override_settings(DAGUERRE_ADJUSTED_IMAGE_PATH='01234567891234')
     def test_upload_to__custom_upload_dir_big(self):
-        hash_path = upload_to(instance=self.instance, filename=self.filename)
-        self.assertTrue(hash_path.startswith('dg/'))
-        self.assertTrue(hash_path.endswith('/{}'.format(self.filename)))
-        self.assertEqual(len(hash_path.split('/')), 4)
-        self.assertTrue(len(hash_path) < 45)
+        with warnings.catch_warnings(record=True) as w:
+            hash_path = upload_to(
+                instance=self.instance, filename=self.filename)
+            self.assertTrue(hash_path.startswith('dg/'))
+            self.assertTrue(hash_path.endswith('/{}'.format(self.filename)))
+            self.assertEqual(len(hash_path.split('/')), 4)
+            self.assertTrue(len(hash_path) < 45)
+
+            # Test the warning message
+            # https://docs.python.org/2/library/warnings.html#testing-warnings
+            warning_message = ('The DAGUERRE_PATH value is more than 13 '
+                               'characters long! Falling back to the default '
+                               'value: "dg".')
+
+            self.assertEqual(len(w), 1)
+            user_warning = w[0]
+            self.assertEqual(user_warning.category, UserWarning)
+            self.assertEqual(user_warning.message.__str__(), warning_message)

--- a/daguerre/tests/unit/test_models.py
+++ b/daguerre/tests/unit/test_models.py
@@ -67,7 +67,7 @@ class AdjustesImageUploadToTestCase(BaseTestCase):
         self.assertEqual(len(hash_path.split('/')), 4)
         self.assertTrue(len(hash_path) < 45)
 
-    @override_settings(DAGUERRE_PATH='img')
+    @override_settings(DAGUERRE_ADJUSTED_IMAGE_PATH='img')
     def test_upload_to__custom_upload_dir(self):
         hash_path = upload_to(instance=self.instance, filename=self.filename)
         self.assertTrue(hash_path.startswith('img/'))
@@ -75,7 +75,7 @@ class AdjustesImageUploadToTestCase(BaseTestCase):
         self.assertEqual(len(hash_path.split('/')), 4)
         self.assertTrue(len(hash_path) < 45)
 
-    @override_settings(DAGUERRE_PATH='0123456789123')
+    @override_settings(DAGUERRE_ADJUSTED_IMAGE_PATH='0123456789123')
     def test_upload_to__custom_upload_dir_small(self):
         hash_path = upload_to(instance=self.instance, filename=self.filename)
         self.assertTrue(hash_path.startswith('0123456789123/'))
@@ -83,7 +83,7 @@ class AdjustesImageUploadToTestCase(BaseTestCase):
         self.assertEqual(len(hash_path.split('/')), 4)
         self.assertTrue(len(hash_path) == 45)
 
-    @override_settings(DAGUERRE_PATH='01234567891234')
+    @override_settings(DAGUERRE_ADJUSTED_IMAGE_PATH='01234567891234')
     def test_upload_to__custom_upload_dir_big(self):
         hash_path = upload_to(instance=self.instance, filename=self.filename)
         self.assertTrue(hash_path.startswith('dg/'))

--- a/docs/guides/settings.rst
+++ b/docs/guides/settings.rst
@@ -1,0 +1,21 @@
+Custom settings
+===============
+
+Adjust the image path
++++++++++++++++++++++
+
+By default, the variations are stored under a hashed directory path that by
+default starts with ``dg/``. This setting can be modified in the project's
+settings by setting the ``DAGUERRE_ADJUSTED_IMAGE_PATH`` variable.
+
+Example:
+
+.. code-block:: django
+
+    # settings.py
+    DAGUERRE_ADJUSTED_IMAGE_PATH = 'img'
+
+
+**WARNING:** The maximum length of the ``DAGUERRE_ADJUSTED_IMAGE_PATH`` string
+is 13 characters. If the string has more than 13 characters, it will gracefully
+fall back to the the default value, i.e. ``dg/``

--- a/docs/guides/settings.rst
+++ b/docs/guides/settings.rst
@@ -4,9 +4,10 @@ Custom settings
 Adjust the image path
 +++++++++++++++++++++
 
-By default, the variations are stored under a hashed directory path that by
-default starts with ``dg/``. This setting can be modified in the project's
-settings by setting the ``DAGUERRE_ADJUSTED_IMAGE_PATH`` variable.
+The variations are stored under a hashed directory path that starts with the
+``dg`` directory by default (e.g. ``dg/ce/2b/7014c0bdbedea0e4f4bf.jpeg``).
+This setting can be modified in the project's settings by setting the
+``DAGUERRE_ADJUSTED_IMAGE_PATH`` variable.
 
 Example:
 
@@ -15,7 +16,10 @@ Example:
     # settings.py
     DAGUERRE_ADJUSTED_IMAGE_PATH = 'img'
 
+which would produce the following path: ``img/ce/2b/7014c0bdbedea0e4f4bf.jpeg``
 
-**WARNING:** The maximum length of the ``DAGUERRE_ADJUSTED_IMAGE_PATH`` string
-is 13 characters. If the string has more than 13 characters, it will gracefully
-fall back to the the default value, i.e. ``dg/``
+
+.. WARNING::
+   The maximum length of the ``DAGUERRE_ADJUSTED_IMAGE_PATH`` string
+   is 13 characters. If the string has more than 13 characters, it will
+   gracefully fall back to the the default value, i.e. ``dg``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Django Daguerre
    :align: right
    :scale: 33 %
    :target: http://en.wikipedia.org/wiki/Louis_Daguerre
-   
+
    Louis Daguerre, Father of Photography
 
 **Django Daguerre** manipulates images on the fly. Use it to scale
@@ -45,6 +45,7 @@ Contents
    guides/template-tags
    guides/areas
    guides/commands
+   guides/settings
 
 
 API Docs


### PR DESCRIPTION
Construct the directory path where the adjusted images will be saved to
using the MD5 hash algorithm.

Can be customized using the **DAGUERRE_PATH** setting set in the project's
settings. If left unspecified, the default value will be used, i.e 'dg'. The
maximum length of the specified string is 13 characters.

Example:
* Default: dg/ce/2b/7014c0bdbedea0e4f4bf.jpeg
* Custom (DAGUERRE_PATH = 'img'): img/ce/2b/7014c0bdbedea0e4f4bf.jpeg

Known issue:
If the extracted hash string is 'ad', ad blockers will block the
image. All occurrences of 'ad' will be replaced with 'ag' since the MD5
hash produces letters from 'a' to 'f'.

Other:
* Improve Unicode compatibility
* Test the *upload_to* function

Connected to issue #102 

A special thanks to @mislavcimpersak 